### PR TITLE
共通パッケージlycee-bot-commonの追加

### DIFF
--- a/fran/external-scripts.json
+++ b/fran/external-scripts.json
@@ -1,11 +1,7 @@
 [
-  "hubot-diagnostics",
   "hubot-help",
-  "hubot-google-images",
-  "hubot-google-translate",
-  "hubot-pugme",
   "hubot-maps",
   "hubot-redis-brain",
   "hubot-rules",
-  "hubot-shipit"
+  "lycee-bot-common"
 ]

--- a/fran/package-lock.json
+++ b/fran/package-lock.json
@@ -1019,7 +1019,7 @@
       "integrity": "sha1-S6HYkP3iSbAx3KA7w36q8yVlbxw="
     },
     "lycee-bot-common": {
-      "version": "github:ryouka0122/lycee-bot-common#9fcc6885986cc108dc56125d35df3a8180617a73",
+      "version": "github:ryouka0122/lycee-bot-common#301f2137879ed0809794fc8673a997713003af46",
       "from": "github:ryouka0122/lycee-bot-common"
     },
     "media-typer": {

--- a/fran/package-lock.json
+++ b/fran/package-lock.json
@@ -1018,6 +1018,10 @@
       "resolved": "https://registry.npmjs.org/log/-/log-1.4.0.tgz",
       "integrity": "sha1-S6HYkP3iSbAx3KA7w36q8yVlbxw="
     },
+    "lycee-bot-common": {
+      "version": "github:ryouka0122/lycee-bot-common#9fcc6885986cc108dc56125d35df3a8180617a73",
+      "from": "github:ryouka0122/lycee-bot-common"
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",

--- a/fran/package.json
+++ b/fran/package.json
@@ -19,7 +19,8 @@
     "hubot-rules": "^0.1.2",
     "hubot-scripts": "^2.17.2",
     "hubot-shipit": "^0.2.1",
-    "hubot-slack": "^4.4.0"
+    "hubot-slack": "^4.4.0",
+    "lycee-bot-common": "github:ryouka0122/lycee-bot-common"
   },
   "engines": {
     "node": "0.10.x"

--- a/reimu/external-scripts.json
+++ b/reimu/external-scripts.json
@@ -1,11 +1,7 @@
 [
-  "hubot-diagnostics",
   "hubot-help",
-  "hubot-google-images",
-  "hubot-google-translate",
-  "hubot-pugme",
   "hubot-maps",
   "hubot-redis-brain",
   "hubot-rules",
-  "hubot-shipit"
+  "lycee-bot-common"
 ]

--- a/reimu/package-lock.json
+++ b/reimu/package-lock.json
@@ -1540,6 +1540,10 @@
         "yallist": "^2.1.2"
       }
     },
+    "lycee-bot-common": {
+      "version": "github:ryouka0122/lycee-bot-common#301f2137879ed0809794fc8673a997713003af46",
+      "from": "github:ryouka0122/lycee-bot-common"
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",

--- a/reimu/package.json
+++ b/reimu/package.json
@@ -20,7 +20,8 @@
     "hubot-rules": "^0.1.2",
     "hubot-scripts": "^2.17.2",
     "hubot-shipit": "^0.2.1",
-    "hubot-slack": "^4.4.0"
+    "hubot-slack": "^4.4.0",
+    "lycee-bot-common": "github:ryouka0122/lycee-bot-common"
   },
   "engines": {
     "node": "0.10.x"


### PR DESCRIPTION
## 追加機能
* 共通処理をまとめるためのパッケージ [lycee-bot-common] を追加
  * https://github.com/ryouka0122/lycee-bot-common
* BOT起動前に手動でパッケージ追加が必要
  * `npm install ryouka0122/lycee-bot-common --no-audit`
  * `npm update --no-audit`