### PR TITLE
pinコマンドのメッセージにバリエーションを持たせる修正

### DIFF
--- a/remilia/run.py
+++ b/remilia/run.py
@@ -6,7 +6,6 @@ import sys
 
 
 # カレントディレクトリをシステムパスに追加
-print(os.getcwd())
 sys.path.append(os.getcwd())
 
 


### PR DESCRIPTION
## 追加機能
* 一定日数を超えるピン止めメッセージにエモティコンを付与するように修正
  * `DEFAULT_PINNED_ITEM_OLD_AGO`より古い場合，「曇りかかった晴れマーク」
  * さらに `ALERT_PINNED_ITEM_OLD_AGO`より古い場合，「炎マーク」に変化
* 古いメッセージがある場合，さらにメッセージをもらえるように修正
  * `ALERT_PINNED_ITEM_OLD_AGO`より古いメッセージがある場合，ランダムで文句を言う

![desktop 7](https://user-images.githubusercontent.com/22113235/41749626-83864c5c-75f2-11e8-9830-620aeec59208.png)

